### PR TITLE
refactor: Remove redundant file outputs in transcription process

### DIFF
--- a/transcribe_me/audio/transcription.py
+++ b/transcribe_me/audio/transcription.py
@@ -99,42 +99,6 @@ def transcribe_with_assemblyai(
     # Write additional information to separate files
     base_name = os.path.splitext(output_path)[0]
 
-    # Speaker Diarization
-    with open(f"{base_name}_speakers.txt", "w", encoding="utf-8") as file:
-        for utterance in transcript.utterances:
-            file.write(f"Speaker {utterance.speaker}: {utterance.text}\n")
-    # Summary
-    with open(f"{base_name}_summary.txt", "w", encoding="utf-8") as file:
-        file.write(transcript.summary)
-
-    # Sentiment Analysis
-    with open(f"{base_name}_sentiment.txt", "w", encoding="utf-8") as file:
-        for result in transcript.sentiment_analysis:
-            file.write(f"Text: {result.text}\n")
-            file.write(f"Sentiment: {result.sentiment}\n")
-            file.write(f"Confidence: {result.confidence}\n")
-            file.write(f"Timestamp: {result.start} - {result.end}\n\n")
-
-    # Topic Detection
-    if transcript.iab_categories:
-        with open(f"{base_name}_topics.txt", "w", encoding="utf-8") as file:
-            # Detailed results
-            file.write("Detailed Topic Results:\n")
-            for result in transcript.iab_categories.results:
-                file.write(f"Text: {result.text}\n")
-                file.write(
-                    f"Timestamp: {result.timestamp.start} - {result.timestamp.end}\n"
-                )
-                for label in result.labels:
-                    file.write(f"  {label.label} (Relevance: {label.relevance})\n")
-                file.write("\n")
-
-            # Summary of all topics
-            file.write("\nTopic Summary:\n")
-            for topic, relevance in transcript.iab_categories.summary.items():
-                file.write(f"Audio is {relevance * 100:.2f}% relevant to {topic}\n")
-
-
 def process_audio_files(
     input_folder: str, output_folder: str, config: Dict[str, Any]
 ) -> None:


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Removed redundant file outputs for speaker diarization, summary, sentiment analysis, and topic detection in the transcription process.
- Streamlined the code by eliminating unnecessary file writing, which simplifies the transcription workflow.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>transcription.py</strong><dd><code>Remove redundant file outputs in transcription process</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

transcribe_me/audio/transcription.py
<li>Removed redundant file outputs for speaker diarization, summary, <br>sentiment analysis, and topic detection.<br> <li> Streamlined the transcription process by eliminating unnecessary file <br>writing.<br>


</details>
    

  </td>
  <td><a href="https://github.com/echohello-dev/transcribe-me/pull/10/files#diff-77a59545fc649bfcce107130d7d2a9e169b3b83c68448c48b4d0a1cf7c88aa09">+0/-36</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

