### PR TITLE
Fix: Ask for confirmation before modifying shell profile files

### DIFF
--- a/transcribe_me/config/config_manager.py
+++ b/transcribe_me/config/config_manager.py
@@ -110,6 +110,7 @@ def install_config() -> None:
 def append_to_shell_profile(line):
     """
     Append a line to the appropriate shell profile file (.zshrc or .bashrc).
+    Asks for confirmation before modifying any files.
 
     Args:
         line (str): The line to append to the shell profile.
@@ -120,10 +121,28 @@ def append_to_shell_profile(line):
     else:
         profile_file = os.path.expanduser("~/.bashrc")
 
-    with open(profile_file, "a") as f:
-        f.write(f"\n{line}\n")
-
-    print(f"{Fore.GREEN}API key added to {profile_file}")
+    # Ask for confirmation before modifying the shell profile
+    print(f"{Fore.YELLOW}Would you like to add the API key to your {profile_file}?")
+    print(f"{Fore.YELLOW}This will append the following line: {line}")
+    confirmation = input(f"{Fore.CYAN}Add to shell profile? (y/N): ").lower()
+    
+    if confirmation == 'y' or confirmation == 'yes':
+        try:
+            with open(profile_file, "a") as f:
+                f.write(f"\n{line}\n")
+            print(f"{Fore.GREEN}API key added to {profile_file}")
+        except PermissionError:
+            print(f"{Fore.RED}Permission denied when trying to write to {profile_file}")
+            print(f"{Fore.YELLOW}You may need to add the API key manually:")
+            print(f"{Fore.YELLOW}{line}")
+        except Exception as e:
+            print(f"{Fore.RED}Error writing to {profile_file}: {e}")
+            print(f"{Fore.YELLOW}You may need to add the API key manually:")
+            print(f"{Fore.YELLOW}{line}")
+    else:
+        print(f"{Fore.YELLOW}Skipped adding API key to shell profile.")
+        print(f"{Fore.YELLOW}Remember to set the environment variable manually:")
+        print(f"{Fore.YELLOW}{line}")
 
 
 def load_config() -> Dict[str, Any]:


### PR DESCRIPTION
Fixes #14

## Problem
The `transcribe-me install` command was attempting to modify shell profile files (like `.zshrc` or `.bashrc`) without asking for user permission. This caused issues for users with read-only configuration files, particularly those using systems like NixOS with home-manager.

## Solution
This PR modifies the `append_to_shell_profile` function to:

1. Ask for user confirmation before modifying any shell profile files
2. Provide a clear message about what will be added to the file
3. Handle permission errors gracefully with helpful error messages
4. Show instructions for manual setup if the user declines or if there's an error

## Changes
- Added user confirmation prompt before modifying shell profiles
- Added error handling for permission issues
- Added fallback instructions for manual environment variable setup
- Improved user messaging throughout the process

## Testing
Manually tested the installation process to verify that:
- The user is prompted before any shell profile modifications
- The user can decline and still proceed with installation
- Error handling works correctly when permission is denied
- Instructions for manual setup are clear and helpful

This change respects user preferences and system configurations while still providing a smooth setup experience.